### PR TITLE
streamlining GHA testing

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -33,7 +33,5 @@
        - shell: bash -l {0}
          run: conda config --show
        - shell: bash -l {0}
-         run: pip install -e . --no-deps --force-reinstall
-       - shell: bash -l {0}
          run: |
            pytest -v spopt --cov=spopt --cov-report=xml


### PR DESCRIPTION
Address [this comment](https://github.com/pysal/spopt/pull/20#pullrequestreview-396055194).

Also, we are generating a `cov` report, but not actually checking/comparing/reporting anything from it. If we would like to set up `codecov`, I can do that easily, I will just need admin access to `spopt`.