### PR TITLE
Add testing for Python 3.8

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -14,7 +14,7 @@
      strategy:
        matrix:
          os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
-         environment-file: [ci/36.yaml, ci/37.yaml]
+         environment-file: [ci/36.yaml, ci/37.yaml, ci/38.yaml]
      steps:
        - uses: actions/checkout@v2
        - uses: goanpeca/setup-miniconda@v1

--- a/ci/38.yaml
+++ b/ci/38.yaml
@@ -1,0 +1,20 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - python =3.8
+  - scipy >=0.11
+  - numpy >=1.3
+  - pandas
+  - networkx
+  - libpysal
+  - geopandas
+  - matplotlib
+  - pytest
+  - pytest-cov
+  - coverage
+  - coveralls
+  - pip
+  - pip:
+    - ortools
+

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ def setup_package():
             'License :: OSI Approved :: BSD License',
             'Programming Language :: Python',
             'Programming Language :: Python :: 3.6',
-            'Programming Language :: Python :: 3.7'
+            'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8'
             ],
           license='3-Clause BSD',
           packages=find_packages(),
@@ -54,7 +55,7 @@ def setup_package():
           extras_require=extras_reqs,
           zip_safe=False,
           cmdclass = {'build.py':build_py},
-          python_requires='>3.6')
+          python_requires='>=3.6')
 
 if __name__ == '__main__':
     setup_package()


### PR DESCRIPTION
This PR:
*  add testing for Python 3.8 in the unittest workflow
* update setup for supported Python versions