### PR TITLE
adding customized codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  notify:
+    after_n_builds: 9
 coverage:
   range: 50..95
   round: nearest
@@ -12,3 +15,8 @@ coverage:
         target: 80%
   ignore:
     - "tests/*"
+comment:
+  layout: "reach, diff, files"
+  behavior: once
+  after_n_builds: 9
+  require_changes: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  range: 50..95
+  round: nearest
+  precision: 1
+  status:
+    project:
+      default:
+        threshold: 2%
+    patch:
+      default:
+        threshold: 2%
+        target: 80%
+  ignore:
+    - "tests/*"


### PR DESCRIPTION
This PR adds a customized `codecov.yml` that:
* allows for a 2% change threshold without failing
* decreases precision to 1 decimal place
* assigns 95% coverage as "complete"
* waits until all 9 builds are complete before commenting here