### PR TITLE
remove ortools

### DIFF
--- a/.ci/37.yaml
+++ b/.ci/37.yaml
@@ -17,3 +17,9 @@ dependencies:
   - pulp
   - coverage
   - coveralls
+  - sphinx>=1.4.3
+  - sphinxcontrib-bibtex==1.0.0
+  - sphinx_bootstrap_theme
+  - numpydoc
+  - nbsphinx
+  

--- a/.ci/37.yaml
+++ b/.ci/37.yaml
@@ -17,7 +17,3 @@ dependencies:
   - pulp
   - coverage
   - coveralls
-  - pip
-  - pip:
-    - ortools
-

--- a/.ci/38.yaml
+++ b/.ci/38.yaml
@@ -17,3 +17,9 @@ dependencies:
   - pulp
   - coverage
   - coveralls
+  - sphinx>=1.4.3
+  - sphinxcontrib-bibtex==1.0.0
+  - sphinx_bootstrap_theme
+  - numpydoc
+  - nbsphinx
+  

--- a/.ci/38.yaml
+++ b/.ci/38.yaml
@@ -17,7 +17,3 @@ dependencies:
   - pulp
   - coverage
   - coveralls
-  - pip
-  - pip:
-    - ortools
-

--- a/.ci/39.yaml
+++ b/.ci/39.yaml
@@ -17,3 +17,9 @@ dependencies:
   - pulp
   - coverage
   - coveralls
+  - sphinx>=1.4.3
+  - sphinxcontrib-bibtex==1.0.0
+  - sphinx_bootstrap_theme
+  - numpydoc
+  - nbsphinx
+  

--- a/.ci/39.yaml
+++ b/.ci/39.yaml
@@ -17,7 +17,3 @@ dependencies:
   - pulp
   - coverage
   - coveralls
-  - pip
-  - pip:
-    - ortools
-

--- a/environment.yml
+++ b/environment.yml
@@ -10,12 +10,9 @@ dependencies:
   - libpysal
   - geopandas>=0.7.0
   - matplotlib
-  - scikit-learn=0.22
+  - scikit-learn>=0.22
   - pytest
   - pytest-cov
   - pulp
   - coverage
   - coveralls
-  - pip
-  - pip:
-    - ortools

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pandas>=1
 networkx
 libpysal
 scikit-learn>=0.22
-geopandas
+geopandas >=0.7
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ numpy>=1.3
 pandas>=1
 networkx
 libpysal
-ortools
 scikit-learn>=0.22
 geopandas
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -3,3 +3,4 @@ sphinxcontrib-bibtex
 sphinx_bootstrap_theme
 numpydoc
 pandoc
+nbsphinx

--- a/spopt/BaseClass.py
+++ b/spopt/BaseClass.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from ortools.linear_solver import pywraplp
 
 
 class BaseSpOptSolver(ABC):
@@ -9,10 +8,7 @@ class BaseSpOptSolver(ABC):
 
     @abstractmethod
     def solve(self):
-        """Solve the optimization model.
-
-        """
-
+        """Solve the optimization model."""
         pass
 
 
@@ -21,45 +17,45 @@ class BaseSpOptExactSolver(BaseSpOptSolver):
 
     Attributes
     ----------
-    
+
     spOptSolver : pywraplp.Solver
         The or-tools MIP solver.
 
     """
 
     def __init__(self, name):
-        """
-        
+        """Initialize.
+
         Parameters
         ----------
-        
         name : str
             The desired name for the model.
-        
         """
-        self.spOptSolver = pywraplp.Solver(
-            name, pywraplp.Solver.CBC_MIXED_INTEGER_PROGRAMMING
-        )
+        try:
+            from ortools.linear_solver import pywraplp
+
+            self.spOptSolver = pywraplp.Solver(
+                name, pywraplp.Solver.CBC_MIXED_INTEGER_PROGRAMMING
+            )
+        except ImportError:
+            raise ImportError(
+                "ortools is a requirement for exact solvers. "
+                "you can install it with `pip install ortools`"
+            )
+
+        self.name = name
 
     def solve(self):
-        """Solve the optimization model.
-
-        """
-
+        """Solve the optimization model."""
         self.spOptSolver.Solve()
 
 
 class BaseSpOptHeuristicSolver(BaseSpOptSolver):
-    """Base class for all spatial optimization model heuristic solvers.
-
-    """
+    """Base class for all spatial optimization model heuristic solvers."""
 
     @abstractmethod
     def solve(self):
-        """Solve the optimization model.
-
-        """
-
+        """Solve the optimization model."""
         pass
 
 

--- a/spopt/BaseClass.py
+++ b/spopt/BaseClass.py
@@ -57,10 +57,3 @@ class BaseSpOptHeuristicSolver(BaseSpOptSolver):
     def solve(self):
         """Solve the optimization model."""
         pass
-
-
-if __name__ != "__main__":
-    # hs = BaseSpOptHeuristicSolver()
-    # hs.solve()
-    es = BaseSpOptExactSolver("tests")
-    es.solve()

--- a/spopt/__init__.py
+++ b/spopt/__init__.py
@@ -1,8 +1,6 @@
 __version__ = "0.1.0"
-# __version__ has to be defined in the first line
 
 
-# import modules/functions
 from .region import MaxPHeuristic
 from .region import RegionKMeansHeuristic
 from .region import Skater


### PR DESCRIPTION
there's been some movement on the ortools package for conda-forge but its not available yet. Thus, while ortools is a hard dependency, we can't release spopt on conda-forge. This temporarily removes it as a dep and we can add it back once things are sorted