### PR TITLE
bump initial version down to 0.0.1

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -2,7 +2,6 @@
  on:
    push:
      branches:
-     - master
      - main
  jobs:
    docs:
@@ -15,27 +14,25 @@
          os: ['ubuntu-latest']
          environment-file: [.ci/39.yaml]
          experimental: [false]
+     defaults:
+       run:
+         shell: bash -l {0}
      steps:
        - uses: actions/checkout@v2
        - uses: conda-incubator/setup-miniconda@v2
          with:
             miniconda-version: 'latest'
-            auto-update-conda: true
+            channels: conda-forge
+            channel-priority: true
+            auto-update-conda: false
             auto-activate-base: false
             environment-file: ${{ matrix.environment-file }}
             activate-environment: test
-       - shell: bash -l {0}
-         run: conda info --all
-       - shell: bash -l {0}
-         run: conda list
-       - shell: bash -l {0}
-         run: conda config --show-sources
-       - shell: bash -l {0}
-         run: conda config --show
-       - shell: bash -l {0}
-         run: pip install -e . --no-deps --force-reinstall
-       - shell: bash -l {0}
-         run: cd docs; make html
+       - run: conda info --all
+       - run: conda list
+       - run: conda config --show-sources
+       - run: conda config --show
+       - run: cd docs; make html
        - name: Commit documentation changes
          run: |
            git clone https://github.com/ammaraskar/sphinx-action-test.git --branch gh-pages --single-branch gh-pages

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,11 @@ with open("%s/__init__.py" % package, "r") as f:
     exec(f.readline())
 
 
+# Fetch README.md for the `long_description`
+with open("README.md", "r", encoding="utf-8") as file:
+    long_description = file.read()
+
+
 def _get_requirements_from_files(groups_files):
     groups_reqlist = {}
 
@@ -36,7 +41,10 @@ def setup_package():
         name=package,
         version=__version__,
         description="Spatial Optimization in PySAL",
+        long_description=long_description,
+        long_description_content_type="text/markdown",
         url="https://github.com/pysal/" + package,  # github repo
+        download_url="https://pypi.org/project/" + package,
         maintainer="PySAL Developers",
         maintainer_email="xin.feng@ucr.edu, jgaboardi@gmail.com",
         keywords="spatial optimization",

--- a/spopt/__init__.py
+++ b/spopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.0.1"
 
 
 from .region import MaxPHeuristic


### PR DESCRIPTION
This PR bumps the initial release version down to `v0.0.1` in order to:
* troubleshoot any issues with the release GHA (#116)
* generate a zenodo DOI (#115)