### PR TITLE
bump version to v0.0.2

### DIFF
--- a/spopt/__init__.py
+++ b/spopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
 
 from .region import MaxPHeuristic


### PR DESCRIPTION
This PR simply increments the version up to `0.0.2` following a manual release of `v0.0.1` on PyPI. This manual release was done prior to a GitHub release of `v0.0.1` in order to facilitate the testing of the automated release+publish workflow.