### PR TITLE
Classify repo as Python

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-language=Python


### PR DESCRIPTION
This PR classifies the `spopt` repo as being 100% (ignores html, tex, etc.) for GitHub searches.