### PR TITLE
add trigger to doc_build action

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,39 +1,44 @@
  name: Build Docs
+ 
  on:
    push:
-     branches:
-     - main
+     # Sequence of patterns matched against refs/tags
+     tags:
+       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+   workflow_dispatch:
+     inputs:
+       version:
+         description: Manual Doc Build Reason
+         default: test
+         required: false
  jobs:
    docs:
-     name: CI (${{ matrix.os }}-${{ matrix.environment-file }})
+     name: build & push docs
      runs-on: ${{ matrix.os }}
-     continue-on-error: ${{ matrix.experimental }}
      timeout-minutes: 90
      strategy:
        matrix:
          os: ['ubuntu-latest']
-         environment-file: [.ci/39.yaml]
+         environment-file: [ci/39.yaml]
          experimental: [false]
      defaults:
        run:
          shell: bash -l {0}
+     
      steps:
-       - uses: actions/checkout@v2
-       - uses: conda-incubator/setup-miniconda@v2
+       - name: checkout repo
+         uses: actions/checkout@v2
+       
+       - name: setup micromamba
+         uses: mamba-org/provision-with-micromamba@main
          with:
-            miniconda-version: 'latest'
-            channels: conda-forge
-            channel-priority: true
-            auto-update-conda: false
-            auto-activate-base: false
-            environment-file: ${{ matrix.environment-file }}
-            activate-environment: test
-       - run: conda info --all
-       - run: conda list
-       - run: conda config --show-sources
-       - run: conda config --show
-       - run: cd docs; make html
-       - name: Commit documentation changes
+           environment-file: ${{ matrix.environment-file }}
+           micromamba-version: 'latest'
+       
+       - name: make docs
+         run: cd docs; make html
+       
+       - name: commit docs
          run: |
            git clone https://github.com/ammaraskar/sphinx-action-test.git --branch gh-pages --single-branch gh-pages
            cp -r docs/_build/html/* gh-pages/
@@ -42,9 +47,10 @@
            git config --local user.name "GitHub Action"
            git add .
            git commit -m "Update documentation" -a || true
-           # The above command will fail if no changes were present, so we ignore
-           # the return code.
-       - name: Push changes
+           # The above command will fail if no changes were present,
+           # so we ignore the return code.
+       
+       - name: push to gh-pages
          uses: ad-m/github-push-action@master
          with:
             branch: gh-pages

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -10,7 +10,7 @@
 
  jobs:
    unittests:
-     name: conda (${{ matrix.os }}, ${{ matrix.environment-file }})
+     name: ${{ matrix.os }}, ${{ matrix.environment-file }}
      runs-on: ${{ matrix.os }}
      timeout-minutes: 30 
      strategy:

--- a/notebooks/reg-k-means.ipynb
+++ b/notebooks/reg-k-means.ipynb
@@ -9,6 +9,8 @@
     "**Authors:** **[Sergio Rey](https://github.com/sjsrey),** **[Xin Feng](https://github.com/xf37),** **[James Gaboardi](https://github.com/jGaboardi)**\n",
     "\n",
     "Regional-k-means is K-means with the constraint that each cluster forms a spatially connected component. The algorithm is developed by [Sergio Rey](https://github.com/sjsrey). This tutorial goes through the following:\n",
+    "\n",
+    "\n",
     "1. a small synthetic example (10x10 lattice)\n",
     "2. a large synthetic example (50x50 lattice)\n",
     "3. an empirical example (Rio Grande do Sul, Brasil)"


### PR DESCRIPTION
This PR:
* adds a manual trigger to the `doc_build.yml` action
* swaps out `conda` for `micromamba` in setting up Python
* minor correction in `reg-k-means.ipynb`
* minor correction in `unittests.yml`