### PR TITLE
update notebook links in conf

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -280,8 +280,8 @@ numpydoc_xref_ignore = {
 
 # This is processed by Jinja2 and inserted before each notebook
 nbsphinx_prolog = r"""
-{% set docname = env.doc2path(env.docname, base='').replace('nblink','ipynb') %}
-{% set fullpath = env.doc2path(env.docname, base='tree/main/').replace('nblink','ipynb') %}
+{% set docname = env.doc2path(env.docname, base='') %}
+{% set fullpath = env.doc2path(env.docname, base='tree/main/') %}
 
 .. only:: html
 


### PR DESCRIPTION
Link at the top on Tutorial pages to the notebooks seem to be broken. This PR attempts a fix.