### PR TITLE
[WIP] allow for precomputed distance matrices

### DIFF
--- a/spopt/region/skater.py
+++ b/spopt/region/skater.py
@@ -168,7 +168,7 @@ class SpanningForest(object):
             if super_verbose:
                 print(self._trace[-1])
         if self.metric == "precomputed":
-            cutdata = dissim
+            cutdata = attribute_kernel
         else:
             cutdata = data
         while current_n_subtrees < n_clusters:  # while we don't have enough regions
@@ -256,11 +256,7 @@ class SpanningForest(object):
                 for l in range(n_subtrees)
             ]
         else:
-            part_scores = []
-            for l in range(n_subtrees):
-                label_data = data[labels == l]
-                values = label_data[label_data.nonzero()]
-                part_scores.append(self.reduction(values))
+            part_scores = [self.reduction(data[labels == l]) for l in range(n_subtrees)]
         return self.reduction(part_scores).item()
 
     def find_cut(

--- a/spopt/region/skater.py
+++ b/spopt/region/skater.py
@@ -29,7 +29,7 @@ class SpanningForest(object):
                    Will be inverted to provide a
                    dissimilarity metric.
         reduction: the reduction applied over all clusters
-                   to provide the map score. When center is false, this is like
+                   to provide the map score. When center is None, this is like
                    a linkage condition in an agglomerative clustering. Average
                    linkage can be achieved using reduction=numpy.average, whereas
                    minimum linkage could be achieved using reduction=numpy.min


### PR DESCRIPTION
This allows for precomputed distance matrices in the skater baseclass, `skater.SpanningForest`. For a usage example:

```python
import numpy
from libpysal import weights
from scipy.spatial import distance_matrix
from spopt.region.skater import SpanningForest

r = numpy.random.normal(size=(10,2))
D = distance_matrix(r,r, p=1) #l1 metric
w = weights.lat2W(5,2) # 5 by 2 lattice

SpanningForest(dissimilarity='precomputed').fit(5, w, D)
```

Now, caveat emptor: the semantics are a little different here @Shruti-Patil, since this converts the score into minimizing the sum of dissimilarities within the clusters, rather than minimizing the distance between features and the feature centroid of the cluster. 