### PR TITLE
access package version in tools/gitcount

### DIFF
--- a/tools/gitcount.ipynb
+++ b/tools/gitcount.ipynb
@@ -20,17 +20,14 @@
    "source": [
     "#  get date of last tag\n",
     "from subprocess import Popen, PIPE\n",
-    "x, err = Popen('git log -1 --tags --simplify-by-decoration --pretty=\"%ai\"| cat', stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=True).communicate()\n",
+    "x, err = Popen(\n",
+    "    'git log -1 --tags --simplify-by-decoration --pretty=\"%ai\"| cat',\n",
+    "    stdin=PIPE,\n",
+    "    stdout=PIPE,\n",
+    "    stderr=PIPE,\n",
+    "    shell=True\n",
+    ").communicate()\n",
     "start_date = x.split()[0].decode('utf-8')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "err"
    ]
   },
   {
@@ -100,7 +97,7 @@
     "import ssl\n",
     "import yaml\n",
     "\n",
-    "context = ssl._create_unverified_context()\n"
+    "context = ssl._create_unverified_context()"
    ]
   },
   {
@@ -109,15 +106,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "CWD = os.path.abspath(os.path.curdir)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "CWD = os.path.abspath(os.path.curdir)\n",
     "CWD"
    ]
   },
@@ -140,11 +129,16 @@
    "outputs": [],
    "source": [
     "# get __version__\n",
-    "f = \"../{package}/__init__.py\".format(package=package_name)\n",
-    "\n",
-    "with open(f, 'r') as initfile:\n",
-    "     exec(initfile.readline())\n",
-    "   "
+    "%run ../spopt/_version.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "__version__ = get_versions()[\"version\"]"
    ]
   },
   {
@@ -193,10 +187,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "identities = {'Levi John Wolf': ('ljwolf', 'Levi John Wolf'),\n",
-    "              'Serge Rey': ('Serge Rey', 'Sergio Rey', 'sjsrey', 'serge'),\n",
-    "              'Wei Kang': ('Wei Kang', 'weikang9009'),\n",
-    "              'Dani Arribas-Bel': ('Dani Arribas-Bel', 'darribas')\n",
+    "identities = {\n",
+    "    'Levi John Wolf': ('ljwolf', 'Levi John Wolf'),\n",
+    "    'Serge Rey': ('Serge Rey', 'Sergio Rey', 'sjsrey', 'serge'),\n",
+    "    'Wei Kang': ('Wei Kang', 'weikang9009'),\n",
+    "    'Dani Arribas-Bel': ('Dani Arribas-Bel', 'darribas')\n",
     "}\n",
     "\n",
     "def regularize_identity(string):\n",
@@ -579,9 +574,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:spopt]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-spopt-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -593,7 +588,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.9.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
xref pysal/spaghetti#654, pysal/libpysal#434

In order to take advantage of using [`tools/gitcount.ipynb`](https://github.com/pysal/spopt/blob/master/tools/gitcount.ipynb) with the newly adopted `versioneer`schema, the version import cell must be split into two cells and changed from:

```python
# get __version__
f = "../{package}/__init__.py".format(package=package_name)
with open(f, "r") as initfile:
     exec(initfile.readline())
```

to:

```python
# get __version__
%run ../spopt/_version.py
```
```python
__version__ = get_versions()["version"]
```