### PR TITLE
install pulp for docs build

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -35,6 +35,10 @@
            environment-file: ${{ matrix.environment-file }}
            micromamba-version: 'latest'
        
+       - name: install pulp via pip
+         shell: bash -l {0}
+         run: pip install pulp
+       
        - name: make docs
          run: cd docs; make html
        


### PR DESCRIPTION
Seems that we need to install pulp for docs build. See failure [here](https://github.com/pysal/spopt/runs/4087183779?check_suite_focus=true).