### PR TITLE
Region-k-means seed

### DIFF
--- a/spopt/region/base.py
+++ b/spopt/region/base.py
@@ -37,15 +37,12 @@ def move_ok(area, source, destination, g, w):
     Parameters
     ----------
 
-    area :
-        ...
-
-    source :
-        ...
-
-    destination :
-        ...
-
+    area : int, numpy.int64
+        Area label.
+    source : numpy.array
+        Source region labels.
+    destination : list
+        destination region labels.
     g : networkx.Graph
         NetworkX representation of ``w``.
     w : libpysal.weights.W
@@ -79,25 +76,20 @@ def ok_moves(candidates, regions, labels_, closest, g, w, areas):
     Parameters
     ----------
 
-    candidates :
-        ...
-
-    regions :
-        ...
-
-    labels_ : list
+    candidates : numpy.array
+        Candidate area labels for moves.
+    regions : list
         Region labels.
-
-    closest :
-        ...
-
+    labels_ : list
+        Region membership labels.
+    closest : numpy.array
+        Closest region labels.
     g : networkx.Graph
         NetworkX representation of ``w``.
     w : libpysal.weights.W
         PySAL weights object.
-
-    areas :
-        ...
+    areas : numpy.array
+        All area labels.
 
     Returns
     -------
@@ -113,6 +105,7 @@ def ok_moves(candidates, regions, labels_, closest, g, w, areas):
         destination = regions[closest[area]]
         if move_ok(area, source, destination, g, w):
             keep.append(area)
+
     return keep
 
 
@@ -122,22 +115,22 @@ def region_neighbors(a_list, region):
     Parameters
     ----------
 
-    a_list :
-        ...
-
-    region :
-        ...
+    a_list : pandas.DataFrame
+        Adjacency and weights information in dataframe format.
+    region : numpy.array
+        Single element array for region label.
 
     Returns
     -------
 
     _region_neighbors_ : list
-        ...
+        Neighboring region labels of ``region``.
 
     """
 
     neighbors = a_list[a_list["focal"].isin(region)].neighbor.values
     _region_neighbors_ = [j for j in neighbors if j not in region]
+
     return _region_neighbors_
 
 
@@ -147,17 +140,16 @@ def _centroid(regions, data):
     Parameters
     ----------
 
-    regions :
-        ...
-
-    data :
-        ...
+    regions : list
+        Region labels.
+    data :  numpy.array
+        All data coordinates.
 
     Returns
     -------
 
     _centroid_ : numpy.array
-        ...
+        Centroid coordinates.
 
     """
 
@@ -171,17 +163,16 @@ def _closest(data, centroids):
     Parameters
     ----------
 
-    data :
-        ...
-
-    centroids :
-        ...
+    data : numpy.array
+        All data coordinates.
+    centroids : numpy.array
+        Centroid coordinates.
 
     Returns
     -------
 
     _closest_ : list
-        ...
+        The closest row in ``centroids`` for each row in ``data``.
 
     """
 
@@ -221,12 +212,10 @@ def is_neighbor(area, region, w):
     Parameters
     ----------
 
-    area :
-        ...
-
-    region :
-        ...
-
+    area : int, numpy.int64
+        Area label
+    region : list
+        Region members.
     w : libpysal.weights.W
         PySAL weights object.
 

--- a/spopt/region/base.py
+++ b/spopt/region/base.py
@@ -44,15 +44,16 @@ def w_to_g(w):
     ----------
 
     w : libpysal.weights.W
-        ...
+        PySAL weights object.
 
     Returns
     -------
 
     g : networkx.Graph
-        ...
+        NetworkX representation of ``w``.
 
     """
+
     g = networkx.Graph()
     for ego, alters in w.neighbors.items():
         for alter in alters:
@@ -76,10 +77,10 @@ def move_ok(area, source, destination, g, w):
         ...
 
     g : networkx.Graph
-        ...
+        NetworkX representation of ``w``.
 
     w : libpysal.weights.W
-        ...
+        PySAL weights object.
 
     Returns
     -------
@@ -125,7 +126,7 @@ def ok_moves(candidates, regions, labels_, closest, g, w, areas):
         ...
 
     w : libpysal.weights.W
-        ...
+        PySAL weights object.
 
     areas :
         ...
@@ -220,26 +221,28 @@ def _closest(data, centroids):
     return _closest_
 
 
-def _seeds(areas, k):
+def _seeds(areas, k, seed):
     """Randomly select `k` seeds from a sequence of areas.
 
     Parameters
     ----------
 
-    areas :
-        ...
-
+    areas : numpy.array
+        Enumeration of ``W`` areas.
     k : int
         The number of desired seeds.
+    seed : int
+        Random state.
 
     Returns
     -------
 
     _seeds_ : numpy.array
-        ...
+        Random labels of clusters to form.
 
     """
 
+    numpy.random.seed(seed)
     _seeds_ = numpy.random.choice(areas, size=k, replace=False)
     return _seeds_
 
@@ -257,14 +260,13 @@ def is_neighbor(area, region, w):
         ...
 
     w : libpysal.weights.W
-        ...
+        PySAL weights object.
 
     Returns
     -------
 
     neighboring : bool
-        ``True`` if area is a neighbor of any member
-        of region otherwise ``False``.
+        ``True`` if area is a neighbor of any member of region otherwise ``False``.
 
     """
 
@@ -282,25 +284,24 @@ def infeasible_components(gdf, w, threshold_var, threshold):
     Parameters
     ----------
     gdf : geopandas.GeoDataFrame, required
-        Geodataframe containing original data
-
+        Geodataframe containing original data.
     w : libpysal.weights.W, required
-        Weights object created from given data
-
+        Weights object created from given data.
     attrs_name : list, required
         Strings for attribute names to measure similarity
         (cols of ``geopandas.GeoDataFrame``).
-
     threshold_var : string, requied
         The name of the spatial extensive attribute variable.
-
     threshold : {int, float}, required
         The threshold value.
 
     Returns
     -------
-    list of infeasible components
+    : list
+        Infeasible components.
+
     """
+
     gdf["_components"] = w.component_labels
     gb = gdf.groupby(by="_components").sum(numeric_only=True)
     gdf.drop(columns="_components", inplace=True)
@@ -317,13 +318,16 @@ def plot_components(gdf, w):
     ----------
     gdf: geopandas.GeoDataframe
 
-    w: libpysal.weights.W defined on gdf
+    w: libpysal.weights.W
+        PySAL weights object defined on ``gdf``.
 
     Returns
     -------
+
     folium.folium.Map
 
     """
+
     cgdf = gdf.copy()
     cgdf["component"] = w.component_labels
     return cgdf.explore(column="component", categorical=True)
@@ -334,40 +338,36 @@ def modify_components(gdf, w, threshold_var, threshold, policy="single"):
 
     Parameters
     ----------
-    gdf : geopandas.GeoDataFrame, required
+
+    gdf : geopandas.GeoDataFrame
         Geodataframe containing original data
-
-    w : libpysal.weights.W, required
-        Weights object created from given data
-
-    attrs_name : list, required
+    w : libpysal.weights.W
+        Weights object created from given data.
+    attrs_name : list
         Strings for attribute names to measure similarity (cols of
         ``geopandas.GeoDataFrame``).
-
-    threshold_var : string, requied
+    threshold_var : str
         The name of the spatial extensive attribute variable.
-
-    threshold : {int, float}, required
+    threshold : {int, float}
         The threshold value.
-
     policy: str
-          'single' will attach an infeasible component to a feasible
-          component based on a single join using the minimum nearest
-          neighbor distance between areas of infeasible components and
-          areas in the largest component. 'multiple' will form a join
-          between each area of an infeasible area and its nearest
-          neighbor area in a feasible component.  'keep' keeps
-          infeasible components and attempts to solve. 'drop' will
-          remove the areas from the smallest components and return a w
-          defined on the feasible components.
-
+        ``'single'`` will attach an infeasible component to a feasible
+        component based on a single join using the minimum nearest
+        neighbor distance between areas of infeasible components and
+        areas in the largest component. ``'multiple'`` will form a join
+        between each area of an infeasible area and its nearest
+        neighbor area in a feasible component. ``'keep'`` keeps
+        infeasible components and attempts to solve. ``'drop'`` will
+        remove the areas from the smallest components and return a ``w``
+        defined on the feasible components.
 
     Returns
     -------
     gdf: geopandas.GeoDataFrame
+        ...
+    w : libpysal.weights.W
+        Weights object created from given data.
 
-    w : libpysal.weights.W, required
-        Weights object created from given data
     """
     ifcs = infeasible_components(gdf, w, threshold_var, threshold)
 
@@ -403,10 +403,10 @@ def form_single_component(gdf, w, linkage="single"):
 
     Parameters
     ----------
-    gdf : GeoDataFrame
-
-    w   : libysal.weights.W
-
+    gdf : geopandas.GeoDataFrame
+        ...
+    w : libysal.weights.W
+        PySAL weights object.
     linkage : str
          `single`: a small component will be joined with the largest
          component by adding a single join based on minimum nearest
@@ -417,8 +417,15 @@ def form_single_component(gdf, w, linkage="single"):
 
     Returns
     -------
-    w  : libpysal.weights.W
+    w : libpysal.weights.W
+        PySAL weights object.
+
     """
+
+    ll = linkage.lower()
+    if ll not in ["single", "multiple"]:
+        raise ValueError(f"Unknown `linkage`: '{linkage}'")
+
     data = numpy.unique(w.component_labels, return_counts=True)
     if len(data[0]) == 1:
         return w
@@ -457,24 +464,24 @@ def form_single_component(gdf, w, linkage="single"):
             dd, jj = tree.query(query_pnts, k=1)
             clas = numpy.where(numpy.isin(w.component_labels, [cl]))[0]
 
-            jj = [lcas[0][j] for j in jj]  # map to idx in gdf
-
-            ll = linkage.lower()
+            # map to idx in gdf
+            jj = [lcas[0][j] for j in jj]
 
             if ll == "single":
                 min_idx = numpy.argmin(dd)
                 j = jj[min_idx]
                 i = clas[min_idx]
                 joins.append((i, j))
-            elif ll == "multiple":
+            else:
                 pairs = zip(clas, jj)
                 joins.extend(list(pairs))
-            else:
-                raise Exception(f"Unknown linkage: {linkage}")
 
         neighbors = copy.deepcopy(w.neighbors)
         for join in joins:
             head, tail = join
             neighbors[head].append(tail)
             neighbors[tail].append(head)
-        return libpysal.weights.W(neighbors)
+
+        w = libpysal.weights.W(neighbors)
+
+        return w

--- a/spopt/region/base.py
+++ b/spopt/region/base.py
@@ -27,8 +27,8 @@ class RegionMixin(object):
         Returns
         -------
 
-        _labels_ :
-            ...
+        _labels_ : list
+            Region labels.
 
         """
 
@@ -78,7 +78,6 @@ def move_ok(area, source, destination, g, w):
 
     g : networkx.Graph
         NetworkX representation of ``w``.
-
     w : libpysal.weights.W
         PySAL weights object.
 
@@ -116,15 +115,14 @@ def ok_moves(candidates, regions, labels_, closest, g, w, areas):
     regions :
         ...
 
-    labels_ :
-        ...
+    labels_ : list
+        Region labels.
 
     closest :
         ...
 
     g : networkx.Graph
-        ...
-
+        NetworkX representation of ``w``.
     w : libpysal.weights.W
         PySAL weights object.
 
@@ -135,7 +133,7 @@ def ok_moves(candidates, regions, labels_, closest, g, w, areas):
     -------
 
     keep : list
-        ...
+        Area labels where moves are OK.
 
     """
 
@@ -283,6 +281,7 @@ def infeasible_components(gdf, w, threshold_var, threshold):
 
     Parameters
     ----------
+
     gdf : geopandas.GeoDataFrame, required
         Geodataframe containing original data.
     w : libpysal.weights.W, required
@@ -297,7 +296,8 @@ def infeasible_components(gdf, w, threshold_var, threshold):
 
     Returns
     -------
-    : list
+
+    list
         Infeasible components.
 
     """
@@ -312,12 +312,12 @@ def infeasible_components(gdf, w, threshold_var, threshold):
 
 
 def plot_components(gdf, w):
-    """Plot to view components of the W for a gdf.
+    """Plot to view components of the W for a ``gdf``.
 
     Parameters
     ----------
     gdf: geopandas.GeoDataframe
-
+        Geodataframe of component data.
     w: libpysal.weights.W
         PySAL weights object defined on ``gdf``.
 
@@ -340,7 +340,7 @@ def modify_components(gdf, w, threshold_var, threshold, policy="single"):
     ----------
 
     gdf : geopandas.GeoDataFrame
-        Geodataframe containing original data
+        Geodataframe containing original data.
     w : libpysal.weights.W
         Weights object created from given data.
     attrs_name : list
@@ -364,11 +364,12 @@ def modify_components(gdf, w, threshold_var, threshold, policy="single"):
     Returns
     -------
     gdf: geopandas.GeoDataFrame
-        ...
+        Geodataframe containing modiefied data.
     w : libpysal.weights.W
         Weights object created from given data.
 
     """
+
     ifcs = infeasible_components(gdf, w, threshold_var, threshold)
 
     if ifcs == numpy.unique(w.component_labels).tolist():
@@ -404,7 +405,7 @@ def form_single_component(gdf, w, linkage="single"):
     Parameters
     ----------
     gdf : geopandas.GeoDataFrame
-        ...
+        Input area data.
     w : libysal.weights.W
         PySAL weights object.
     linkage : str

--- a/spopt/region/base.py
+++ b/spopt/region/base.py
@@ -7,36 +7,6 @@ import networkx
 from scipy.spatial import KDTree
 
 
-class RegionMixin(object):
-    """Mixin class for all region solvers."""
-
-    _solver_type = "regionalizer"
-
-    def solve_assign(self, X, adjacency):
-        """
-
-        Parameters
-        ----------
-
-        X :
-            ...
-
-        adjacency :
-            ...
-
-        Returns
-        -------
-
-        _labels_ : list
-            Region labels.
-
-        """
-
-        self.solve(X, adjacency)
-        _labels_ = self.labels_
-        return _labels_
-
-
 def w_to_g(w):
     """Get a ``networkx`` graph from a PySAL W.
 

--- a/spopt/region/maxp.py
+++ b/spopt/region/maxp.py
@@ -715,13 +715,13 @@ class MaxPHeuristic(BaseSpOptHeuristicSolver):
         Default is ``False``.
 
     policy : str
-        Defaults to ``single`` to attach infeasible components using a
+        Defaults to ``'single'`` to attach infeasible components using a
         single linkage between the area in the infeasible component
         with the smallest nearest neighbor distance to an area in a
-        feasible component. ``multiple`` adds joins for each area
+        feasible component. ``'multiple'`` adds joins for each area
         in an infeasible component and their nearest neighbor area in a
-        feasible component. ``keep`` attempts to solve without
-        modification (useful for debugging). ``drop`` removes areas in
+        feasible component. ``'keep'`` attempts to solve without
+        modification (useful for debugging). ``'drop'`` removes areas in
         infeasible components before solving.
 
 
@@ -783,7 +783,7 @@ class MaxPHeuristic(BaseSpOptHeuristicSolver):
         max_iterations_construction=99,
         max_iterations_sa=ITERSA,
         verbose=False,
-        policy="attach",
+        policy="single",
     ):
 
         self.gdf = gdf

--- a/spopt/region/region_k_means.py
+++ b/spopt/region/region_k_means.py
@@ -24,7 +24,7 @@ from .base import (
 )
 
 
-def region_k_means(X, n_clusters, w, drop_islands=True):
+def region_k_means(X, n_clusters, w, drop_islands=True, seed=0):
     """Solve the region-K-means problem with the constraint
     that each cluster forms a spatially connected component.
 
@@ -40,6 +40,8 @@ def region_k_means(X, n_clusters, w, drop_islands=True):
     drop_islands : bool
         Drop observations that are islands (``True``) or keep them (``False``).
         Default is ``True``.
+    seed : int
+        Random state to pass into ``_seeds()``. Default is ``0``.
 
     Returns
     -------
@@ -59,7 +61,7 @@ def region_k_means(X, n_clusters, w, drop_islands=True):
     a_list = w.to_adjlist(remove_symmetric=False, drop_islands=drop_islands)
     areas = numpy.arange(w.n).astype(int)
     k = n_clusters
-    seeds = _seeds(areas, k)
+    seeds = _seeds(areas, k, seed)
 
     # initial assignment phase
     label = numpy.array([-1] * w.n).astype(int)
@@ -144,6 +146,8 @@ class RegionKMeansHeuristic(BaseSpOptHeuristicSolver):
     drop_islands : bool
         Drop observations that are islands (``True``) or keep them (``False``).
         Default is ``True``.
+    seed : int
+        Random state to pass into ``_seeds()``. Default is ``0``.
 
     Attributes
     ----------
@@ -158,17 +162,23 @@ class RegionKMeansHeuristic(BaseSpOptHeuristicSolver):
 
     """
 
-    def __init__(self, data, n_clusters, w, drop_islands=True):
+    def __init__(self, data, n_clusters, w, drop_islands=True, seed=0):
         self.data = data
         self.w = w
         self.n_clusters = n_clusters
         self.drop_islands = drop_islands
+        self.seed = seed
 
     def solve(self):
         """Solve the region k-means heuristic."""
         centroid, label, iters = region_k_means(
-            self.data, self.n_clusters, self.w, self.drop_islands
+            self.data,
+            self.n_clusters,
+            self.w,
+            drop_islands=self.drop_islands,
+            seed=self.seed,
         )
+
         self.labels_ = label
         self.centroids_ = centroid
         self.iters_ = iters

--- a/spopt/tests/test_maxp.py
+++ b/spopt/tests/test_maxp.py
@@ -104,7 +104,6 @@ class TestMaxPHeuristic:
 
     def test_infeasible_components(self):
         ifcs = infeasible_components(self.mexico, self.w, "count", 35)
-        print(ifcs)
         numpy.testing.assert_array_equal(ifcs, [0])
 
     def test_plot_components(self):
@@ -127,6 +126,39 @@ class TestMaxPHeuristic:
         assert w1.neighbors[0] != w.neighbors[0]
         assert w1.neighbors[1] != w.neighbors[1]
 
+    @pytest.mark.filterwarnings("ignore:The weights matrix is not fully")
+    def test_modify_components_policy_error(self):
+        policy = "Triple"
+        with pytest.raises(ValueError, match=f"Unknown `policy`: '{policy}'"):
+            modify_components(
+                self.gdf,
+                libpysal.weights.Queen.from_dataframe(self.gdf),
+                "var",
+                6,
+                policy=policy,
+            )
+
+    @pytest.mark.filterwarnings("ignore:The weights matrix is not fully")
+    def test_modify_components_xfeasible_error(self):
+        with pytest.raises(ValueError, match="No feasible components found in input."):
+            modify_components(
+                self.gdf,
+                libpysal.weights.Queen.from_dataframe(self.gdf),
+                "var",
+                100,
+            )
+
+    @pytest.mark.filterwarnings("ignore:The weights matrix is not fully")
+    def test_form_single_component_already_single(self):
+        _gdf = self.gdf[10:20].copy()
+        w = libpysal.weights.Queen.from_dataframe(_gdf)
+        single_component = form_single_component(_gdf, w)
+
+        numpy.testing.assert_array_equal(
+            numpy.zeros(_gdf.shape[0]), single_component.component_labels
+        )
+
+    @pytest.mark.filterwarnings("ignore:The weights matrix is not fully")
     def test_form_single_component_error(self):
         linkage = "Triple"
         with pytest.raises(ValueError, match=f"Unknown `linkage`: '{linkage}'"):

--- a/spopt/tests/test_maxp.py
+++ b/spopt/tests/test_maxp.py
@@ -5,6 +5,7 @@ import pytest
 from shapely.geometry import Polygon, box
 from spopt.region import MaxPHeuristic
 from spopt.region.maxp import infeasible_components, modify_components, plot_components
+from spopt.region.base import form_single_component
 
 
 # Mexican states
@@ -125,3 +126,12 @@ class TestMaxPHeuristic:
         assert gdf1.shape[0] == 55
         assert w1.neighbors[0] != w.neighbors[0]
         assert w1.neighbors[1] != w.neighbors[1]
+
+    def test_form_single_component_error(self):
+        linkage = "Triple"
+        with pytest.raises(ValueError, match=f"Unknown `linkage`: '{linkage}'"):
+            form_single_component(
+                self.gdf,
+                libpysal.weights.Queen.from_dataframe(self.gdf),
+                linkage=linkage,
+            )

--- a/spopt/tests/test_region_k_means.py
+++ b/spopt/tests/test_region_k_means.py
@@ -16,9 +16,10 @@ class TestRegionKMeansHeuristic:
         # small 3 x 3 example w/ 3 regions
         dim_small = 3
         self.w_small = libpysal.weights.lat2W(dim_small, dim_small)
+        numpy.random.seed(RANDOM_STATE)
         self.data_small = numpy.random.normal(size=(self.w_small.n, dim_small))
         self.reg_small = 3
-        self.known_labels_small = [1, 1, 2, 0, 1, 2, 0, 2, 2]
+        self.known_labels_small = [1, 1, 1, 0, 1, 2, 0, 0, 2]
 
         # large 20 x 20 example broken into 2 islands w/ 5 regions
         hori, vert = 20, 20
@@ -34,19 +35,20 @@ class TestRegionKMeansHeuristic:
         self.limit_index = 30
         self.known_labels_large = [1] * self.limit_index
 
-    @pytest.mark.xfail
     @pytest.mark.filterwarnings("ignore:The weights matrix is not fully")
     def test_region_k_means_heuristic_synth_small(self):
-        numpy.random.seed(RANDOM_STATE)
-        model = RegionKMeansHeuristic(self.data_small, self.reg_small, self.w_small)
+        model = RegionKMeansHeuristic(
+            self.data_small, self.reg_small, self.w_small, seed=RANDOM_STATE
+        )
         model.solve()
 
         numpy.testing.assert_equal(model.labels_, self.known_labels_small)
 
     @pytest.mark.filterwarnings("ignore:The weights matrix is not fully")
     def test_region_k_means_heuristic_synth_large(self):
-        numpy.random.seed(RANDOM_STATE)
-        model = RegionKMeansHeuristic(self.data_large, self.reg_large, self.w_large)
+        model = RegionKMeansHeuristic(
+            self.data_large, self.reg_large, self.w_large, seed=RANDOM_STATE
+        )
         model.solve()
 
         labs_ = model.labels_[: self.limit_index]


### PR DESCRIPTION
Resolves #213.

After more digging I found that we were not providing the functionality of actually passing in a seed value to the [`base._seeds()`](https://github.com/pysal/spopt/blob/main/spopt/region/base.py#L223-L244) function. Therefore, the resultant `numpy.random.choice()` function within could never be reproduced and was screwing tests up.

This PR also fills in all docstrings in `base.py`, cleans up several raised error logics, and adds several more test cases.