### PR TITLE
utilize `BaseSpOptExactSolver`

### DIFF
--- a/spopt/BaseClass.py
+++ b/spopt/BaseClass.py
@@ -11,15 +11,7 @@ class BaseSpOptSolver(ABC):
 
 
 class BaseSpOptExactSolver(BaseSpOptSolver):
-    """Base class for all spatial optimization model exact solvers.
-
-    Attributes
-    ----------
-
-    spOptSolver : pywraplp.Solver
-        The or-tools MIP solver.
-
-    """
+    """Base class for all spatial optimization model exact solvers."""
 
     def __init__(self, name):
         """Initialize.
@@ -29,23 +21,12 @@ class BaseSpOptExactSolver(BaseSpOptSolver):
         name : str
             The desired name for the model.
         """
-        try:
-            from ortools.linear_solver import pywraplp
-
-            self.spOptSolver = pywraplp.Solver(
-                name, pywraplp.Solver.CBC_MIXED_INTEGER_PROGRAMMING
-            )
-        except ImportError:
-            raise ImportError(
-                "ortools is a requirement for exact solvers. "
-                "you can install it with `pip install ortools`"
-            )
-
         self.name = name
 
+    @abstractmethod
     def solve(self):
         """Solve the optimization model."""
-        self.spOptSolver.Solve()
+        pass
 
 
 class BaseSpOptHeuristicSolver(BaseSpOptSolver):

--- a/spopt/locate/base.py
+++ b/spopt/locate/base.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 
-from ..BaseClass import BaseSpOptSolver
+from ..BaseClass import BaseSpOptExactSolver
 from typing import TypeVar
 
 import numpy as np
@@ -17,7 +17,7 @@ STATUS_CODES = {
 }
 
 
-class LocateSolver(BaseSpOptSolver):
+class LocateSolver(BaseSpOptExactSolver):
     """Base class for the ``locate`` package."""
 
     def __init__(self, name: str, problem: pulp.LpProblem):


### PR DESCRIPTION
This PR removes the `ortools` import in `BaseClass` so that `BaseSpOptExactSolver` can then be inherited by `LocateSolver` instances.

xref #298 #49