### PR TITLE
doc build env correction

### DIFF
--- a/.ci/310.yaml
+++ b/.ci/310.yaml
@@ -20,9 +20,3 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  # docs
-  - nbsphinx
-  - numpydoc
-  - sphinx
-  - sphinxcontrib-bibtex
-  - sphinx_bootstrap_theme

--- a/.ci/311.yaml
+++ b/.ci/311.yaml
@@ -23,6 +23,6 @@ dependencies:
   # docs
   - nbsphinx
   - numpydoc
-  - sphinx<=4.5.0
+  - sphinx
   - sphinxcontrib-bibtex
   - sphinx_bootstrap_theme


### PR DESCRIPTION
This PR removes the [`.ci/311.yml`](https://github.com/pysal/spopt/blob/main/.ci/311.yaml) `sphinx` version pin that I forgot to remove in #309 and also removes the doc building packages from [`.ci/310.yml`](https://github.com/pysal/spopt/blob/main/.ci/310.yaml) since we will be building documentation with the `.ci/311.yml` environment.