### PR TITLE
add versioneer action

### DIFF
--- a/.github/workflows/versioneer.yml
+++ b/.github/workflows/versioneer.yml
@@ -20,11 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
       - name: Install and run versioneer
         run: |
-          pip install versioneer[toml]
+          pip install versioneer
           versioneer install
       - name: Blacken code
         uses: psf/black@stable

--- a/.github/workflows/versioneer.yml
+++ b/.github/workflows/versioneer.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
+        #with:
+        #  python-version: "3.10"
       - name: Install and run versioneer
         run: |
           pip install versioneer

--- a/.github/workflows/versioneer.yml
+++ b/.github/workflows/versioneer.yml
@@ -1,0 +1,50 @@
+# See https://github.com/python-versioneer/python-versioneer
+name: "Update Versioneer"
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Manual Versioneer Run
+        default: test
+        required: false
+  schedule:
+    - cron: "0 6 1 * *" # 1st day of each month at 06:00 UTC
+  push:
+    paths:
+      - "setup.cfg"
+      - ".github/workflows/versioneer.yml"
+
+jobs:
+  versioneer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install and run versioneer
+        run: |
+          pip install versioneer[toml]
+          versioneer install
+      - name: Blacken code
+        uses: psf/black@stable
+        with:
+          options: "--verbose"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          path: versioneer.py
+      - name: Ignore changes in __init__
+        run: |
+          git reset -- spopt/__init__.py
+          git checkout -- spopt/__init__.py
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: "Update Versioneer"
+          branch: update-versioneer
+          base: main
+          commit-message: "[Bot] Update Versioneer"
+
+          body: |
+            Automatic update of Versioneer by the `versioneer.yml` workflow.

--- a/.github/workflows/versioneer.yml
+++ b/.github/workflows/versioneer.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-        #with:
-        #  python-version: "3.10"
+        with:
+          python-version: "3.10"
       - name: Install and run versioneer
         run: |
           pip install versioneer

--- a/.github/workflows/versioneer.yml
+++ b/.github/workflows/versioneer.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - name: Install and run versioneer
         run: |
           pip install versioneer

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup, find_packages
-from distutils.command.build_py import build_py
 import versioneer
 
 package = "spopt"  # name of package
@@ -34,9 +33,9 @@ def setup_package():
     extras_reqs = reqs
 
     setup(
-        name=package,
+        name=package,  # needed by GitHub dependency graph
         version=versioneer.get_version(),
-        cmdclass=versioneer.get_cmdclass({"build_py": build_py}),
+        cmdclass=versioneer.get_cmdclass(),
         description="Spatial Optimization in PySAL",
         long_description=long_description,
         long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR resolves #339.

Adapted from [`spaghetti`](https://github.com/pysal/spaghetti/blob/main/.github/workflows/versioneer.yml)'s version because we haven't adopted `pyproject.toml` here yet (#325) (specifically `{"build_py": build_py}` needs to be removed [here](https://github.com/pysal/spopt/blob/f2ac58f806737e82726ef34ac36c253ea7e0ca56/setup.py#L39)).

* passing --> https://github.com/jGaboardi/spopt/actions/runs/3907911521/jobs/6677596851