### PR TITLE
default to binary assignment for clients

### DIFF
--- a/spopt/locate/base.py
+++ b/spopt/locate/base.py
@@ -238,7 +238,7 @@ class FacilityModelBuilder:
         var_name: str,
         low_bound=0,
         up_bound=1,
-        lp_category=pulp.LpInteger,
+        lp_category=pulp.LpBinary,
     ) -> None:
         """Client assignment integer decision variables (used for allocation).
 
@@ -257,9 +257,9 @@ class FacilityModelBuilder:
             The lower bound for variable values. Set to ``None`` for no lower bound.
         up_bound : int (default 1)
             The upper bound for variable values. Set to ``None`` for no upper bound.
-        lp_category : pulp.LpVariable parameter
+        lp_category : pulp.LpVariable
             The category this variable is in,
-            ``pulp.LpInteger`` or ``pulp.LpContinuous``.
+            ``pulp.LpBinary`` or ``pulp.LpContinuous``.
 
         Returns
         -------


### PR DESCRIPTION
This PR (hopefully) provides a solution to #364. Simply swapping out `pulp.LpInteger` for `pulp.LpBinary` as the default in [`add_client_assign_variable`](https://github.com/pysal/spopt/blob/main/spopt/locate/base.py#L241) seems to do the trick and tests pass locally. @ljwolf Can you try this out on your data to see if it resolves the issue?
