### PR TITLE
solve b410

### DIFF
--- a/spopt/locate/coverage.py
+++ b/spopt/locate/coverage.py
@@ -452,8 +452,8 @@ class LSCP(LocateSolver, BaseOutputMixin):
             distances,
             service_radius,
             predefined_facilities_arr,
-            facility_capacity_arr,
             demand_quantity_arr,
+            facility_capacity_arr,
             name,
         )
 


### PR DESCRIPTION
Bug #410 means that no capacitated LSCP will ever be solvable through `from_geodataframe()`. The check requires that demand weight is less than capacity, but transposes the capacity and demand arrays. So, all cases where capacity is greater than demand have an error raised saying that there is not enough capacity, while all cases where capacity is *less than* demand proceed to solve and return infeasible. 

This fixes the transposition. 