### PR TITLE
test against Apple silicon

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,7 +34,7 @@
          include:
            - environment-file: ci/312-latest.yaml
              os: macos-latest
-           - environment-file: ci/envs/312-latest.yaml
+           - environment-file: ci/312-latest.yaml
              os: macos-14 # Apple Silicon
            - environment-file: ci/312-latest.yaml
              os: windows-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,6 +34,8 @@
          include:
            - environment-file: ci/312-latest.yaml
              os: macos-latest
+           - environment-file: ci/envs/312-latest.yaml
+             os: macos-14 # Apple Silicon
            - environment-file: ci/312-latest.yaml
              os: windows-latest
        fail-fast: false


### PR DESCRIPTION
This PR adds a specific Apple Silicon environment to the CI matrix:
* xref https://github.com/pysal/momepy/pull/542/
* [GitHub Blog](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/)