### PR TITLE
re- lint & re-format repo – #438

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 files: "spopt\/"
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.1.9"
+    rev: "v0.3.3"
     hooks:
       - id: ruff
       - id: ruff-format

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -8,7 +7,6 @@ import sphinx_bootstrap_theme
 
 # import your package to obtain the version info to display on the docs website
 import spopt
-
 
 # -- General configuration ------------------------------------------------
 
@@ -46,7 +44,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "spopt"
-copyright = "2020-, pysal developers"
+copyright = "2020-, pysal developers"  # noqa: A001
 author = "pysal developers"
 
 # The version info for the project you're documenting, acts as replacement for
@@ -85,7 +83,8 @@ html_theme = "bootstrap"
 html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
 html_title = f"{project} v{version} Manual"
 
-# (Optional) Logo of your package. Should be small enough to fit the navbar (ideally 24x24).
+# (Optional) Logo of your package.
+# Should be small enough to fit the navbar (ideally 24x24).
 # Path should be relative to the ``_static`` files directory.
 # html_logo = "_static/images/package_logo.jpg"
 
@@ -299,7 +298,7 @@ nbsphinx_prolog = r"""
     \nbsphinxstartnotebook{\scriptsize\noindent\strut
     \textcolor{gray}{The following section was generated from
     \sphinxcode{\sphinxupquote{\strut {{ docname | escape_latex }}}} \dotfill}}
-"""
+"""  # noqa: E501
 
 # This is processed by Jinja2 and inserted after each notebook
 nbsphinx_epilog = r"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,10 +81,9 @@ include = ["spopt", "spopt.*"]
 
 [tool.ruff]
 line-length = 88
-select = ["E", "F", "W", "I", "UP", "N", "B", "A", "C4", "SIM", "ARG"]
-exclude = ["spopt/tests/*", "docs/*"]
+lint.select = ["E", "F", "W", "I", "UP", "N", "B", "A", "C4", "SIM", "ARG"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
  "*__init__.py" = [
      "F401",  # imported but unused
      "F403",  # star import; unable to detect undefined names

--- a/spopt/region/components.py
+++ b/spopt/region/components.py
@@ -1,6 +1,7 @@
 """
 Checking for connected components in a graph.
 """
+
 __author__ = "Sergio J. Rey <srey@asu.edu>"
 
 

--- a/spopt/region/csgraph_utils.py
+++ b/spopt/region/csgraph_utils.py
@@ -4,6 +4,7 @@ Utility functions for graph-related operations with sparse adjacency matrices
 [compressed sparse graph routines](
 https://docs.scipy.org/doc/scipy/reference/sparse.csgraph.html).
 """
+
 import numpy as np
 from scipy.sparse import csgraph as csg
 from scipy.sparse import csr_matrix

--- a/spopt/tests/conftest.py
+++ b/spopt/tests/conftest.py
@@ -1,8 +1,8 @@
-import pytest
 import warnings
 
 import geopandas
 import numpy
+import pytest
 import shapely
 
 from spopt.locate.util import simulated_geo_points

--- a/spopt/tests/test_azp.py
+++ b/spopt/tests/test_azp.py
@@ -1,7 +1,6 @@
-import libpysal
 import geopandas
+import libpysal
 import numpy
-
 from packaging.version import Version
 
 from spopt.region import AZP

--- a/spopt/tests/test_c_p_median.py
+++ b/spopt/tests/test_c_p_median.py
@@ -1,19 +1,14 @@
-from spopt.locate.base import (
-    FacilityModelBuilder,
-    LocateSolver,
-    T_FacModel,
-    SpecificationError,
-)
+import os
+
 import numpy
 import pandas
-import geopandas
 import pulp
-import spaghetti
+import pytest
 
 from spopt.locate import PMedian
-from spopt.locate.util import simulated_geo_points
-import pytest
-import os
+from spopt.locate.base import (
+    SpecificationError,
+)
 
 
 class TestSyntheticLocate:
@@ -160,9 +155,12 @@ class TestRealWorldLocate:
         schools_priority_3_arr = numpy.array(schools_priority_3)
         with pytest.raises(
             SpecificationError,
-            match="Problem is infeasible. The predefined facilities can't be fulfilled, ",
+            match=(
+                "Problem is infeasible. "
+                "The predefined facilities can't be fulfilled, "
+            ),
         ):
-            pmedian = PMedian.from_cost_matrix(
+            PMedian.from_cost_matrix(
                 self.cost_matrix,
                 self.demand,
                 self.p_facility,
@@ -174,9 +172,12 @@ class TestRealWorldLocate:
     def test_no_capacity_data_predefined_facilities_error(self):
         with pytest.raises(
             SpecificationError,
-            match="Data on the capacity of the facility is missing, so the model cannot be calculated.",
+            match=(
+                "Data on the capacity of the facility is missing, "
+                "so the model cannot be calculated."
+            ),
         ):
-            pmedian = PMedian.from_cost_matrix(
+            PMedian.from_cost_matrix(
                 self.cost_matrix,
                 self.demand,
                 self.p_facility,
@@ -190,7 +191,7 @@ class TestRealWorldLocate:
             SpecificationError,
             match="Problem is infeasible. The highest possible capacity",
         ):
-            pmedian = PMedian.from_cost_matrix(
+            PMedian.from_cost_matrix(
                 self.cost_matrix,
                 demand_test,
                 self.p_facility,

--- a/spopt/tests/test_clscp-so.py
+++ b/spopt/tests/test_clscp-so.py
@@ -1,11 +1,10 @@
+# ruff: noqa: N999
+
 import numpy
-import geopandas
 import pulp
-import spaghetti
+import pytest
 
 from spopt.locate import LSCP
-from spopt.locate.util import simulated_geo_points
-import pytest
 
 
 class TestSyntheticLocate:

--- a/spopt/tests/test_knearest_p_median.py
+++ b/spopt/tests/test_knearest_p_median.py
@@ -1,16 +1,11 @@
-import numpy
 import geopandas
-import pandas
+import numpy
 import pulp
+import pytest
 from shapely.geometry import Point
 
-from spopt.locate.p_median import KNearestPMedian
 from spopt.locate.base import SpecificationError
-import os
-import pickle
-import platform
-import pytest
-import warnings
+from spopt.locate.p_median import KNearestPMedian
 
 
 class TestKNearestPMedian:
@@ -50,11 +45,11 @@ class TestKNearestPMedian:
         assert isinstance(result, KNearestPMedian)
 
         with pytest.raises(AttributeError):
-            result.cli2fac
+            result.cli2fac  # noqa: B018
         with pytest.raises(AttributeError):
-            result.fac2cli
+            result.fac2cli  # noqa: B018
         with pytest.raises(AttributeError):
-            result.mean_dist
+            result.mean_dist  # noqa: B018
 
     def test_solve(self):
         self.k_nearest_pmedian.solve(self.solver)

--- a/spopt/tests/test_locate_util.py
+++ b/spopt/tests/test_locate_util.py
@@ -1,5 +1,5 @@
 import pytest
-import spaghetti
+
 from spopt.locate.util import simulated_geo_points
 
 

--- a/spopt/tests/test_lscp.py
+++ b/spopt/tests/test_lscp.py
@@ -1,24 +1,19 @@
-from spopt.locate.base import FacilityModelBuilder
-import numpy
-import geopandas
-import pandas
-import pulp
-import spaghetti
-from shapely.geometry import Point, Polygon
-
-from spopt.locate import LSCP
-from spopt.locate.util import simulated_geo_points
 import os
 import pickle
 import platform
-import pytest
 import warnings
 
-operating_system = platform.platform()[:7].lower()
-if operating_system == "windows":
-    WINDOWS = True
-else:
-    WINDOWS = False
+import geopandas
+import numpy
+import pandas
+import pulp
+import pytest
+from shapely.geometry import Point, Polygon
+
+from spopt.locate import LSCP
+from spopt.locate.base import FacilityModelBuilder
+
+WINDOWS = platform.platform()[:7].lower() == "windows"
 
 
 class TestSyntheticLocate:
@@ -44,9 +39,9 @@ class TestSyntheticLocate:
         assert isinstance(result, LSCP)
 
         with pytest.raises(AttributeError):
-            result.cli2fac
+            result.cli2fac  # noqa: B018
         with pytest.raises(AttributeError):
-            result.fac2cli
+            result.fac2cli  # noqa: B018
 
     def test_lscp_facility_client_array_from_cost_matrix(self):
         with open(self.dirpath + "lscp_fac2cli.pkl", "rb") as f:
@@ -254,13 +249,15 @@ class TestErrorsWarnings:
             )
 
     def test_error_lscp_different_crs(self):
-        with pytest.warns(
-            UserWarning, match="Facility geodataframe contains mixed type"
+        with (
+            pytest.warns(
+                UserWarning, match="Facility geodataframe contains mixed type"
+            ),
+            pytest.raises(ValueError, match="Geodataframes crs are different: "),
         ):
-            with pytest.raises(ValueError, match="Geodataframes crs are different: "):
-                LSCP.from_geodataframe(
-                    self.gdf_dem_crs, self.gdf_fac, "geometry", "geometry", 10
-                )
+            LSCP.from_geodataframe(
+                self.gdf_dem_crs, self.gdf_fac, "geometry", "geometry", 10
+            )
 
     def test_warning_lscp_demand_geodataframe(self):
         with pytest.warns(UserWarning, match="Demand geodataframe contains mixed type"):

--- a/spopt/tests/test_lscpb.py
+++ b/spopt/tests/test_lscpb.py
@@ -1,18 +1,16 @@
-import numpy
+import os
+import pickle
+import warnings
+
 import geopandas
+import numpy
 import pandas
 import pulp
-import spaghetti
+import pytest
 from shapely.geometry import Point, Polygon
 
 from spopt.locate import LSCPB
 from spopt.locate.base import FacilityModelBuilder
-from spopt.locate.util import simulated_geo_points
-
-import os
-import pickle
-import warnings
-import pytest
 
 
 class TestSyntheticLocate:
@@ -47,11 +45,11 @@ class TestSyntheticLocate:
         assert isinstance(result, LSCPB)
 
         with pytest.raises(AttributeError):
-            result.cli2fac
+            result.cli2fac  # noqa: B018
         with pytest.raises(AttributeError):
-            result.fac2cli
+            result.fac2cli  # noqa: B018
         with pytest.raises(AttributeError):
-            result.backup_perc
+            result.backup_perc  # noqa: B018
 
     def test_lscpb_facility_client_array_from_cost_matrix(self):
         with open(self.dirpath + "lscpb_fac2cli.pkl", "rb") as f:
@@ -278,18 +276,20 @@ class TestErrorsWarnings:
             self.gdf_dem_buffered["geometry"] = self.gdf_dem.buffer(2)
 
     def test_error_lscpb_different_crs(self):
-        with pytest.warns(
-            UserWarning, match="Facility geodataframe contains mixed type"
+        with (
+            pytest.warns(
+                UserWarning, match="Facility geodataframe contains mixed type"
+            ),
+            pytest.raises(ValueError, match="Geodataframes crs are different: "),
         ):
-            with pytest.raises(ValueError, match="Geodataframes crs are different: "):
-                LSCPB.from_geodataframe(
-                    self.gdf_dem_crs,
-                    self.gdf_fac,
-                    "geometry",
-                    "geometry",
-                    10,
-                    pulp.PULP_CBC_CMD(msg=False),
-                )
+            LSCPB.from_geodataframe(
+                self.gdf_dem_crs,
+                self.gdf_fac,
+                "geometry",
+                "geometry",
+                10,
+                pulp.PULP_CBC_CMD(msg=False),
+            )
 
     def test_warning_lscpb_demand_geodataframe(self):
         with pytest.warns(UserWarning, match="Demand geodataframe contains mixed type"):

--- a/spopt/tests/test_maxp.py
+++ b/spopt/tests/test_maxp.py
@@ -2,7 +2,9 @@ import geopandas
 import libpysal
 import numpy
 import pytest
+from packaging.version import Version
 from shapely.geometry import box
+
 from spopt.region import MaxPHeuristic
 from spopt.region.base import (
     form_single_component,
@@ -10,9 +12,6 @@ from spopt.region.base import (
     modify_components,
     plot_components,
 )
-
-from packaging.version import Version
-
 
 # see gh:spopt#437
 LIBPYSAL_GE_48 = Version(libpysal.__version__) >= Version("4.8.0")

--- a/spopt/tests/test_mclp.py
+++ b/spopt/tests/test_mclp.py
@@ -1,24 +1,19 @@
-from spopt.locate.base import FacilityModelBuilder
-import numpy
-import geopandas
-import pandas
-import pulp
-import spaghetti
-from shapely.geometry import Point, Polygon
-
-from spopt.locate import MCLP
-from spopt.locate.util import simulated_geo_points
 import os
 import pickle
 import platform
-import pytest
 import warnings
 
-operating_system = platform.platform()[:7].lower()
-if operating_system == "windows":
-    WINDOWS = True
-else:
-    WINDOWS = False
+import geopandas
+import numpy
+import pandas
+import pulp
+import pytest
+from shapely.geometry import Point, Polygon
+
+from spopt.locate import MCLP
+from spopt.locate.base import FacilityModelBuilder
+
+WINDOWS = platform.platform()[:7].lower() == "windows"
 
 
 class TestSyntheticLocate:
@@ -56,13 +51,13 @@ class TestSyntheticLocate:
         assert isinstance(result, MCLP)
 
         with pytest.raises(AttributeError):
-            result.cli2fac
+            result.cli2fac  # noqa: B018
         with pytest.raises(AttributeError):
-            result.fac2cli
+            result.fac2cli  # noqa: B018
         with pytest.raises(AttributeError):
-            result.n_cli_uncov
+            result.n_cli_uncov  # noqa: B018
         with pytest.raises(AttributeError):
-            result.perc_cov
+            result.perc_cov  # noqa: B018
 
     def test_mclp_facility_client_array_from_cost_matrix(self):
         with open(self.dirpath + "mclp_fac2cli.pkl", "rb") as f:
@@ -294,7 +289,7 @@ class TestRealWorldLocate:
         with pytest.raises(RuntimeError, match="Model is not solved: Infeasible."):
             mclp.solve(pulp.PULP_CBC_CMD(msg=False))
 
-    def test_attribute_error_fac2cli_MCLP_facility_client_array(self):
+    def test_attribute_error_fac2cli_mclp_facility_client_array(self):
         mclp = MCLP.from_geodataframe(
             self.demand_points_gdf,
             self.facility_points_gdf,
@@ -309,9 +304,9 @@ class TestRealWorldLocate:
         with pytest.raises(
             AttributeError, match="'MCLP' object has no attribute 'fac2cli'"
         ):
-            mclp.fac2cli
+            mclp.fac2cli  # noqa: B018
 
-    def test_attribute_error_cli2fac_MCLP_facility_client_array(self):
+    def test_attribute_error_cli2fac_mclp_facility_client_array(self):
         mclp = MCLP.from_geodataframe(
             self.demand_points_gdf,
             self.facility_points_gdf,
@@ -326,9 +321,9 @@ class TestRealWorldLocate:
         with pytest.raises(
             AttributeError, match="'MCLP' object has no attribute 'cli2fac'"
         ):
-            mclp.cli2fac
+            mclp.cli2fac  # noqa: B018
 
-    def test_attribute_error_ncliuncov_MCLP_facility_client_array(self):
+    def test_attribute_error_ncliuncov_mclp_facility_client_array(self):
         mclp = MCLP.from_geodataframe(
             self.demand_points_gdf,
             self.facility_points_gdf,
@@ -343,9 +338,9 @@ class TestRealWorldLocate:
         with pytest.raises(
             AttributeError, match="'MCLP' object has no attribute 'n_cli_uncov'"
         ):
-            mclp.n_cli_uncov
+            mclp.n_cli_uncov  # noqa: B018
 
-    def test_attribute_error_percentage_MCLP_facility_client_array(self):
+    def test_attribute_error_percentage_mclp_facility_client_array(self):
         mclp = MCLP.from_geodataframe(
             self.demand_points_gdf,
             self.facility_points_gdf,
@@ -405,19 +400,21 @@ class TestErrorsWarnings:
             )
 
     def test_error_mclp_different_crs(self):
-        with pytest.warns(
-            UserWarning, match="Facility geodataframe contains mixed type"
+        with (
+            pytest.warns(
+                UserWarning, match="Facility geodataframe contains mixed type"
+            ),
+            pytest.raises(ValueError, match="Geodataframes crs are different: "),
         ):
-            with pytest.raises(ValueError, match="Geodataframes crs are different: "):
-                MCLP.from_geodataframe(
-                    self.gdf_dem_crs,
-                    self.gdf_fac,
-                    "geometry",
-                    "geometry",
-                    "weight",
-                    10,
-                    2,
-                )
+            MCLP.from_geodataframe(
+                self.gdf_dem_crs,
+                self.gdf_fac,
+                "geometry",
+                "geometry",
+                "weight",
+                10,
+                2,
+            )
 
     def test_warning_mclp_demand_geodataframe(self):
         with pytest.warns(UserWarning, match="Demand geodataframe contains mixed type"):

--- a/spopt/tests/test_p_center.py
+++ b/spopt/tests/test_p_center.py
@@ -1,24 +1,19 @@
-from spopt.locate.base import FacilityModelBuilder
-import numpy
-import geopandas
-import pandas
-import pulp
-import spaghetti
-from shapely.geometry import Point, Polygon
-
-from spopt.locate import PCenter
-from spopt.locate.util import simulated_geo_points
 import os
 import pickle
 import platform
-import pytest
 import warnings
 
-operating_system = platform.platform()[:7].lower()
-if operating_system == "windows":
-    WINDOWS = True
-else:
-    WINDOWS = False
+import geopandas
+import numpy
+import pandas
+import pulp
+import pytest
+from shapely.geometry import Point, Polygon
+
+from spopt.locate import PCenter
+from spopt.locate.base import FacilityModelBuilder
+
+WINDOWS = platform.platform()[:7].lower() == "windows"
 
 
 class TestSyntheticLocate:
@@ -44,9 +39,9 @@ class TestSyntheticLocate:
         assert isinstance(result, PCenter)
 
         with pytest.raises(AttributeError):
-            result.cli2fac
+            result.cli2fac  # noqa: B018
         with pytest.raises(AttributeError):
-            result.fac2cli
+            result.fac2cli  # noqa: B018
 
     def test_pcenter_facility_client_array_from_cost_matrix(self):
         with open(self.dirpath + "pcenter_fac2cli.pkl", "rb") as f:
@@ -260,13 +255,15 @@ class TestErrorsWarnings:
             )
 
     def test_error_pcenter_different_crs(self):
-        with pytest.warns(
-            UserWarning, match="Facility geodataframe contains mixed type"
+        with (
+            pytest.warns(
+                UserWarning, match="Facility geodataframe contains mixed type"
+            ),
+            pytest.raises(ValueError, match="Geodataframes crs are different: "),
         ):
-            with pytest.raises(ValueError, match="Geodataframes crs are different: "):
-                PCenter.from_geodataframe(
-                    self.gdf_dem_crs, self.gdf_fac, "geometry", "geometry", 2
-                )
+            PCenter.from_geodataframe(
+                self.gdf_dem_crs, self.gdf_fac, "geometry", "geometry", 2
+            )
 
     def test_warning_pcenter_demand_geodataframe(self):
         with pytest.warns(UserWarning, match="Demand geodataframe contains mixed type"):

--- a/spopt/tests/test_p_dispersion.py
+++ b/spopt/tests/test_p_dispersion.py
@@ -1,23 +1,17 @@
-from spopt.locate.base import FacilityModelBuilder
-import numpy
+import os
+import platform
+
 import geopandas
+import numpy
 import pandas
 import pulp
-import spaghetti
+import pytest
 from shapely.geometry import Polygon
 
 from spopt.locate import PDispersion
-from spopt.locate.util import simulated_geo_points
+from spopt.locate.base import FacilityModelBuilder
 
-import os
-import platform
-import pytest
-
-operating_system = platform.platform()[:7].lower()
-if operating_system == "windows":
-    WINDOWS = True
-else:
-    WINDOWS = False
+WINDOWS = platform.platform()[:7].lower() == "windows"
 
 
 class TestSyntheticLocate:
@@ -41,9 +35,9 @@ class TestSyntheticLocate:
         assert isinstance(result, PDispersion)
 
         with pytest.raises(AttributeError):
-            result.cli2fac
+            result.cli2fac  # noqa: B018
         with pytest.raises(AttributeError):
-            result.fac2clif
+            result.fac2clif  # noqa: B018
 
     def test_p_dispersion_from_geodataframe(self):
         pdispersion = PDispersion.from_geodataframe(

--- a/spopt/tests/test_p_median.py
+++ b/spopt/tests/test_p_median.py
@@ -1,24 +1,19 @@
-from spopt.locate.base import FacilityModelBuilder
-import numpy
-import geopandas
-import pandas
-import pulp
-import spaghetti
-from shapely.geometry import Point, Polygon
-
-from spopt.locate import PMedian
-from spopt.locate.util import simulated_geo_points
 import os
 import pickle
 import platform
-import pytest
 import warnings
 
-operating_system = platform.platform()[:7].lower()
-if operating_system == "windows":
-    WINDOWS = True
-else:
-    WINDOWS = False
+import geopandas
+import numpy
+import pandas
+import pulp
+import pytest
+from shapely.geometry import Point, Polygon
+
+from spopt.locate import PMedian
+from spopt.locate.base import FacilityModelBuilder
+
+WINDOWS = platform.platform()[:7].lower() == "windows"
 
 
 class TestSyntheticLocate:
@@ -48,11 +43,11 @@ class TestSyntheticLocate:
         assert isinstance(result, PMedian)
 
         with pytest.raises(AttributeError):
-            result.cli2fac
+            result.cli2fac  # noqa: B018
         with pytest.raises(AttributeError):
-            result.fac2cli
+            result.fac2cli  # noqa: B018
         with pytest.raises(AttributeError):
-            result.mean_dist
+            result.mean_dist  # noqa: B018
 
     def test_pmedian_facility_client_array_from_cost_matrix(self):
         with open(self.dirpath + "pmedian_fac2cli.pkl", "rb") as f:
@@ -290,13 +285,15 @@ class TestErrorsWarnings:
             )
 
     def test_error_pmedian_different_crs(self):
-        with pytest.warns(
-            UserWarning, match="Facility geodataframe contains mixed type"
+        with (
+            pytest.warns(
+                UserWarning, match="Facility geodataframe contains mixed type"
+            ),
+            pytest.raises(ValueError, match="Geodataframes crs are different: "),
         ):
-            with pytest.raises(ValueError, match="Geodataframes crs are different: "):
-                PMedian.from_geodataframe(
-                    self.gdf_dem_crs, self.gdf_fac, "geometry", "geometry", "weight", 2
-                )
+            PMedian.from_geodataframe(
+                self.gdf_dem_crs, self.gdf_fac, "geometry", "geometry", "weight", 2
+            )
 
     def test_warning_pmedian_demand_geodataframe(self):
         with pytest.warns(UserWarning, match="Demand geodataframe contains mixed type"):

--- a/spopt/tests/test_random_regions.py
+++ b/spopt/tests/test_random_regions.py
@@ -2,11 +2,9 @@ import geopandas
 import libpysal
 import numpy
 import pytest
-
 from packaging.version import Version
 
 from spopt.region import RandomRegion, RandomRegions
-
 
 # see gh:spopt#437
 LIBPYSAL_GE_48 = Version(libpysal.__version__) >= Version("4.8.0")
@@ -174,7 +172,7 @@ class TestRandomRegionSynthetic:
     def test_random_regions_error_contig(self):
         with pytest.raises(ValueError, match="Order of `area_ids`"):
 
-            class _shell_w_:
+            class _shell_w_:  # noqa: N801
                 def __init__(self):
                     self.id_order = [1, 0]
 

--- a/spopt/tests/test_region_k_means.py
+++ b/spopt/tests/test_region_k_means.py
@@ -2,12 +2,10 @@ import libpysal
 import numpy
 import pandas
 import pytest
-
 from packaging.version import Version
 
 from spopt.region import RegionKMeansHeuristic
 from spopt.region.spenclib.utils import lattice
-
 
 # see gh:spopt#437
 LIBPYSAL_GE_48 = Version(libpysal.__version__) >= Version("4.8.0")

--- a/spopt/tests/test_region_util.py
+++ b/spopt/tests/test_region_util.py
@@ -1,11 +1,10 @@
-import libpysal
 import geopandas
+import libpysal
 import networkx
 import numpy
 import pytest
 
 import spopt.region.util as util
-
 
 RANDOM_STATE = 123456
 
@@ -81,7 +80,7 @@ class TestRegionUtil:
         observed = util.dict_from_graph_attr(graph, "test_data")
         assert observed == desired
 
-        desired_array = dict()
+        desired_array = {}
         for node in data_dict:
             desired_array[node] = numpy.array(data_dict[node])
         observed = util.dict_from_graph_attr(graph, "test_data", array_values=True)

--- a/spopt/tests/test_skater.py
+++ b/spopt/tests/test_skater.py
@@ -2,13 +2,11 @@ import geopandas
 import libpysal
 import numpy
 import pytest
+from packaging.version import Version
 from scipy.optimize import OptimizeWarning
 from sklearn.metrics import pairwise as skm
 
-from packaging.version import Version
-
 from spopt.region import Skater
-
 
 # see gh:spopt#437
 LIBPYSAL_GE_48 = Version(libpysal.__version__) >= Version("4.8.0")
@@ -98,15 +96,20 @@ class TestSkater:
         self.mexico["count"] = 1
         args = self.mexico, self.w_mexico, self.default_attrs_mexico
         n_clusters, floor, trace, islands = 10, 3, True, "ignore"
-        kws = dict(n_clusters=n_clusters, floor=floor, trace=trace, islands=islands)
-        sfkws = dict(
-            dissimilarity=skm.manhattan_distances,
-            affinity=None,
-            reduction=numpy.sum,
-            center=numpy.mean,
-            verbose=2,
-        )
-        kws.update(dict(spanning_forest_kwds=sfkws))
+        kws = {
+            "n_clusters": n_clusters,
+            "floor": floor,
+            "trace": trace,
+            "islands": islands,
+        }
+        sfkws = {
+            "dissimilarity": skm.manhattan_distances,
+            "affinity": None,
+            "reduction": numpy.sum,
+            "center": numpy.mean,
+            "verbose": 2,
+        }
+        kws.update({"spanning_forest_kwds": sfkws})
         numpy.random.seed(RANDOM_STATE)
         model = Skater(*args, **kws)
         model.solve()
@@ -119,9 +122,14 @@ class TestSkater:
         self.columbus["count"] = 1
         args = self.columbus, self.w_columbus, self.attrs_columbus
         n_clusters, floor, trace, islands = 10, 5, True, "increase"
-        kws = dict(n_clusters=n_clusters, floor=floor, trace=trace, islands=islands)
-        sfkws = dict(dissimilarity=skm.euclidean_distances)
-        kws.update(dict(spanning_forest_kwds=sfkws))
+        kws = {
+            "n_clusters": n_clusters,
+            "floor": floor,
+            "trace": trace,
+            "islands": islands,
+        }
+        sfkws = {"dissimilarity": skm.euclidean_distances}
+        kws.update({"spanning_forest_kwds": sfkws})
         numpy.random.seed(RANDOM_STATE)
         model = Skater(*args, **kws)
         with pytest.warns(OptimizeWarning, match="MSF contains no valid moves after"):
@@ -136,9 +144,14 @@ class TestSkater:
             self.columbus["count"] = 1
             args = self.columbus, self.w_columbus, self.attrs_columbus
             n_clusters, floor, trace, islands = 10, 10, True, "increase"
-            kws = dict(n_clusters=n_clusters, floor=floor, trace=trace, islands=islands)
-            sfkws = dict(dissimilarity=skm.euclidean_distances)
-            kws.update(dict(spanning_forest_kwds=sfkws))
+            kws = {
+                "n_clusters": n_clusters,
+                "floor": floor,
+                "trace": trace,
+                "islands": islands,
+            }
+            sfkws = {"dissimilarity": skm.euclidean_distances}
+            kws.update({"spanning_forest_kwds": sfkws})
             numpy.random.seed(RANDOM_STATE)
             model = Skater(*args, **kws)
             with pytest.warns(
@@ -152,14 +165,19 @@ class TestSkater:
         self.columbus["count"] = 1
         args = self.columbus, self.w_columbus, self.attrs_columbus
         n_clusters, floor, trace, islands = 4, 2, False, "ignore"
-        kws = dict(n_clusters=n_clusters, floor=floor, trace=trace, islands=islands)
-        sfkws = dict(
-            dissimilarity=None,
-            affinity=skm.cosine_distances,
-            reduction=numpy.sum,
-            center=numpy.std,
-        )
-        kws.update(dict(spanning_forest_kwds=sfkws))
+        kws = {
+            "n_clusters": n_clusters,
+            "floor": floor,
+            "trace": trace,
+            "islands": islands,
+        }
+        sfkws = {
+            "dissimilarity": None,
+            "affinity": skm.cosine_distances,
+            "reduction": numpy.sum,
+            "center": numpy.std,
+        }
+        kws.update({"spanning_forest_kwds": sfkws})
         numpy.random.seed(RANDOM_STATE)
         model = Skater(*args, **kws)
         with pytest.warns(RuntimeWarning, match="divide by zero encountered in log"):

--- a/spopt/tests/test_spenc.py
+++ b/spopt/tests/test_spenc.py
@@ -1,11 +1,9 @@
 import geopandas
 import libpysal
 import numpy
-
 from packaging.version import Version
 
 from spopt.region import Spenc
-
 
 # see gh:spopt#437
 LIBPYSAL_GE_48 = Version(libpysal.__version__) >= Version("4.8.0")

--- a/spopt/tests/test_ward.py
+++ b/spopt/tests/test_ward.py
@@ -1,11 +1,9 @@
 import geopandas
 import libpysal
 import numpy
-
 from packaging.version import Version
 
 from spopt.region import WardSpatial
-
 
 # see gh:spopt#437
 LIBPYSAL_GE_48 = Version(libpysal.__version__) >= Version("4.8.0")


### PR DESCRIPTION
This PR:
* resolves #438 
* re-lints & re-formats with latest `ruff`
* extends linting & formatting to the `tests/*` directory.