### PR TITLE
Update numpy array comparisons to use isin

### DIFF
--- a/spopt/region/csgraph_utils.py
+++ b/spopt/region/csgraph_utils.py
@@ -139,7 +139,7 @@ def sub_adj_matrix(adj, nodes, wo_nodes=None):
 
     """
     if wo_nodes is not None:
-        mask = np.in1d(nodes, wo_nodes, invert=True)
+        mask = np.isin(nodes, wo_nodes, invert=True)
         nodes = nodes[mask]
     nodes = nodes[:, None]
     return csr_matrix(adj[nodes, nodes.T])


### PR DESCRIPTION
# PR Summary
This small PR resolves the NumPy deprecation warnings of `np.in1d`:
```python
/home/runner/work/spopt/spopt/spopt/region/csgraph_utils.py:142: DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
```