### PR TITLE
Improve CONTRIBUTING.md for new contributors

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,9 +1,28 @@
 # Contributing Guidelines for `spopt`
 
-Thank you for your interest in contributing! We work primarily on Github. Please review the contributing procedures [here](http://pysal.org/getting_started#for-developers) and [here](https://github.com/pysal/pysal/wiki/GitHub-Standard-Operating-Procedures) so that we can accept your contributions! Alternatively, contact someone in the [development chat channel](https://gitter.im//pysal/pysal).
+Thank you for your interest in contributing to `spopt`! We work primarily on
+GitHub and welcome contributions in the form of bug reports, documentation
+improvements, and code enhancements.
+
+Please review the general PySAL contributing procedures here:
+- http://pysal.org/getting_started#for-developers
+- https://github.com/pysal/pysal/wiki/GitHub-Standard-Operating-Procedures
+
+Alternatively, you can contact contributors via the PySAL development chat:
+https://gitter.im/pysal/pysal
 
 
-## Style and format
+## Getting Started
 
-1. At the time of this writing, Python 3.10, 3.11, and 3.12 are the officially supported versions.
-2. This project implements the linting and formatting conventions of [`ruff`](https://docs.astral.sh/ruff/) on all incoming Pull Requests. To ensure a PR is properly linted and formatted prior to creating a Pull Request, [install `pre-commit`](https://pre-commit.com/#installation) in your development environment and then [set up the configuration of pre-commit hooks](https://pre-commit.com/#3-install-the-git-hook-scripts). 
+This document provides basic guidance for setting up a local development
+environment for `spopt`. It is intended to complement the broader PySAL
+developer documentation linked above.
+
+
+## Installation (Development)
+
+First, fork the repository on GitHub and clone your fork locally:
+
+```bash
+git clone https://github.com/<your-username>/spopt.git
+cd spopt


### PR DESCRIPTION
This PR improves CONTRIBUTING.md by adding clearer guidance for:
- Local development setup
- Running tests
- Building documentation

This follows up on the discussion in issue #481.

