### PR TITLE
Fix infinite loop issue in maxp heuristic

### DIFF
--- a/spopt/region/maxp.py
+++ b/spopt/region/maxp.py
@@ -504,7 +504,7 @@ def _pick_move_area(
                 left_areas = np.delete(rla, pasi)
                 ws = weight.sparse
                 cc = connected_components(ws[left_areas, :][:, left_areas])
-                if cc[0] == 1:
+                if cc[0] == 1 and set(weight.neighbors[rla[pasi]]) - set(left_areas):
                     potential_areas.append(rla[pasi])
         else:
             continue


### PR DESCRIPTION
This pull request fixes an issue with the Max-P Heuristic algorithm that can cause infinite looping in certain cases. If none of the candidates identified by the _pick_move_area() function border another region, the simulated annealing procedure gets stuck in the while loop without ever decreasing the annealing temperature. There may be other ways to fix this problem, but here I just added an additional check to the _pick_move_area() function that requires a move candidate to have at least one neighbor that is not assigned the same region as itself.