### PR TITLE
Max-p unconnected area fix

### DIFF
--- a/spopt/region/maxp.py
+++ b/spopt/region/maxp.py
@@ -223,7 +223,12 @@ def _construction_phase(
             neighbor_polys = deepcopy(weight.neighbors[p])
 
             if len(neighbor_polys) == 0:
-                labels[p] = -1
+                if threshold_array[p] >= spatial_thre:
+                    c += 1
+                    labels[p] = c
+                    region_list[c] = [p]
+                else:
+                    labels[p] = -1
             else:
                 c += 1
                 labeled_id, spatial_attr_total = _grow_cluster_for_poly(

--- a/spopt/region/maxp.py
+++ b/spopt/region/maxp.py
@@ -222,32 +222,23 @@ def _construction_phase(
 
             neighbor_polys = deepcopy(weight.neighbors[p])
 
-            if len(neighbor_polys) == 0:
-                if threshold_array[p] >= spatial_thre:
-                    c += 1
-                    labels[p] = c
-                    region_list[c] = [p]
-                    region_spatial_attr[c] = threshold_array[p]
-                else:
-                    labels[p] = -1
-            else:
-                c += 1
-                labeled_id, spatial_attr_total = _grow_cluster_for_poly(
-                    labels,
-                    threshold_array,
-                    p,
-                    neighbor_polys,
-                    c,
-                    weight,
-                    spatial_thre,
-                )
+            c += 1
+            labeled_id, spatial_attr_total = _grow_cluster_for_poly(
+                labels,
+                threshold_array,
+                p,
+                neighbor_polys,
+                c,
+                weight,
+                spatial_thre,
+            )
 
-                if spatial_attr_total < spatial_thre:
-                    c -= 1
-                    enclave.extend(labeled_id)
-                else:
-                    region_list[c] = labeled_id
-                    region_spatial_attr[c] = spatial_attr_total
+            if spatial_attr_total < spatial_thre:
+                c -= 1
+                enclave.extend(labeled_id)
+            else:
+                region_list[c] = labeled_id
+                region_spatial_attr[c] = spatial_attr_total
         num_regions = len(region_list)
 
         for i, _l in enumerate(labels):

--- a/spopt/region/maxp.py
+++ b/spopt/region/maxp.py
@@ -227,6 +227,7 @@ def _construction_phase(
                     c += 1
                     labels[p] = c
                     region_list[c] = [p]
+                    region_spatial_attr[c] = threshold_array[p]
                 else:
                     labels[p] = -1
             else:


### PR DESCRIPTION
Github is making the files changed window more complicated than it needs to be, but this pull request just drops the if/else associated with the condition 'len(neighbor_polys) == 0'. This check for an area with no neighbors is unnecessary, and will cause unexpected errors with some inputs. There are two cases to consider:

If the area that has no neighbors has a spatially extensive attribute that is large enough to be its own region, then the existing code would assign it as an enclave. This will lead to an error later on when enclaves are assigned, as it is unable to be assigned to a neighboring region. If we instead let the area be passed through the _grow_cluster_for_polygon() function, then the area will be allowed to form a region on its own, which is what we want to happen.

The other case is when the area with no neighbors has a spatially extensive attribute that is too small to be its own region. This will only ever occur if the policy parameter is set to ‘keep’. Whether or not this check for no neighbors is kept, areas with no neighbors and below the threshold will get assigned as an enclave, resulting in a later error when assigning enclaves. The error that is currently thrown is not very intuitive, and could possibly be cleaned up, but it is unlikely that a ‘keep’ policy is widely used beyond debugging.