### PR TITLE
Use non-strict threshold when identifying candidate move areas

### DIFF
--- a/spopt/region/maxp.py
+++ b/spopt/region/maxp.py
@@ -498,7 +498,7 @@ def _pick_move_area(
         rla = np.array(region_lists[k])
         rasa = threshold_array[rla]
         lost_sa = v - rasa
-        pas_indices = np.where(lost_sa > threshold)[0]
+        pas_indices = np.where(lost_sa >= threshold)[0]
         if pas_indices.size > 0:
             for pasi in pas_indices:
                 left_areas = np.delete(rla, pasi)

--- a/spopt/tests/test_region/test_maxp.py
+++ b/spopt/tests/test_region/test_maxp.py
@@ -35,13 +35,13 @@ class TestMaxPHeuristic:
 
         # labels for:
         # count=4, threshold=10, top_n=5
-        self.complex_labels = [2, 2, 1, 1, 1, 1, 1, 1, 1, 3, 3, 1, 3, 3, 3]
-        self.complex_labels += [1, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 1, 1, 2, 2, 2]
+        self.complex_labels = [2, 2, 2, 2, 2, 1, 3, 1, 1, 3, 3, 1, 1, 3, 3]
+        self.complex_labels += [1, 3, 1, 1, 1, 3, 1, 2, 2, 2, 2, 1, 1, 3, 2, 3, 3]
 
         # labels for one variable column:
         # count=1, threshold=5, top_n=5
-        self.var1_labels = [3, 3, 6, 2, 2, 2, 2, 4, 2, 4, 5, 2, 5, 1, 1, 5, 1]
-        self.var1_labels += [4, 5, 5, 1, 1, 3, 3, 6, 3, 6, 4, 4, 6, 6, 4]
+        self.var1_labels = [4, 4, 6, 2, 2, 6, 2, 5, 3, 3, 3, 2, 3, 1, 1, 5, 1]
+        self.var1_labels += [5, 3, 5, 1, 1, 4, 4, 4, 6, 6, 6, 2, 4, 2, 5]
 
         # components
         n_cols = 5


### PR DESCRIPTION
The max-p-regions problem uses a non-strict threshold, requiring that regions have a spatially extensive attribute greater than or equal to a predetermined threshold. This PR replaces > with >= in the pick_move_area() function to align with the non-strict threshold definition. With this improvement, when areas are identified as candidates to be moved in the simulated annealing phase, the remaining parts of the region are required to be >= the minimum region threshold, rather than strictly greater than it. The simulated annealing algorithm works with a strict threshold as originally written, but the results will generally not be as good with a lower number of potential move candidates identified. As this improvement affects the simulated annealing algorithm path, the expected result for 2 test cases needed to be updated as well.