### PR TITLE
fix: expose AZP variants in region API

### DIFF
--- a/spopt/region/__init__.py
+++ b/spopt/region/__init__.py
@@ -1,4 +1,4 @@
-from .azp import AZP
+from .azp import AZP, AZPBasicTabu, AZPReactiveTabu, AZPSimulatedAnnealing
 from .base import w_to_g
 from .maxp import MaxPHeuristic
 from .random_region import RandomRegion, RandomRegions

--- a/spopt/tests/test_region/test_azp.py
+++ b/spopt/tests/test_region/test_azp.py
@@ -3,7 +3,7 @@ import libpysal
 import numpy
 from packaging.version import Version
 
-from spopt.region import AZP
+from spopt.region import AZP, AZPBasicTabu, AZPReactiveTabu, AZPSimulatedAnnealing
 
 # see gh:spopt#437
 LIBPYSAL_GE_48 = Version(libpysal.__version__) >= Version("4.8.0")
@@ -15,6 +15,12 @@ RANDOM_STATE = 123456
 # Mexican states
 pth = libpysal.examples.get_path("mexicojoin.shp")
 MEXICO = geopandas.read_file(pth)
+
+
+def test_azp_variants_exposed_in_region_api():
+    assert AZPBasicTabu is not None
+    assert AZPReactiveTabu is not None
+    assert AZPSimulatedAnnealing is not None
 
 
 class TestAZP:


### PR DESCRIPTION
This PR exposes the existing AZP variant solvers in the public region API so users can import `AZPSimulatedAnnealing`, `AZPBasicTabu`, and `AZPReactiveTabu` directly from `spopt.region`, and it adds a focused regression test to lock that import behaviour in place; the change is intentionally minimal and only surfaces already implemented classes without altering solver logic.
