### PR TITLE
fix: correct FRLM summary coverage percent

### DIFF
--- a/spopt/locate/flow.py
+++ b/spopt/locate/flow.py
@@ -2183,7 +2183,8 @@ class FRLM(FRLMCoverageMixin, FRLMNodeCoverageMixin, FRLMSolverStatsMixin):
         dataframes["coverage"] = pd.DataFrame(coverage_data)
 
         covered_flow_sum = sum(
-            coverage.get("coverage", 0) for coverage in self.flow_coverage.values()
+            coverage.get("covered_volume", 0)
+            for coverage in self.flow_coverage.values()
         )
         total_flow = sum(self.flows.values())
         coverage_pct = covered_flow_sum / total_flow * 100

--- a/spopt/tests/test_locate/test_flow.py
+++ b/spopt/tests/test_locate/test_flow.py
@@ -391,6 +391,18 @@ class TestFRLMOutputsAndReporting:
         assert "destination" in dfs["coverage"].columns
         assert "covered_proportion" in dfs["coverage"].columns
 
+        covered = dfs["coverage"]["covered_volume"].sum()
+        total = dfs["coverage"]["flow_volume"].sum()
+        expected_pct = (covered / total) * 100 if total > 0 else 0
+        summary_pct = float(
+            dfs["summary"]
+            .loc[dfs["summary"]["Metric"] == "Coverage %", "Value"]
+            .iloc[0]
+            .replace("Flow Coverage: ", "")
+            .replace("%", "")
+        )
+        assert summary_pct == pytest.approx(expected_pct, abs=0.01)
+
     def test_solver_details(self, setup_solved_model):
         model = setup_solved_model
         details = model.get_solver_details()


### PR DESCRIPTION
This PR fixes FRLM dataframe summary reporting by calculating `Coverage %` from `covered_volume` instead of a non-existent key, and adds a focused regression assertion that compares the exported summary percentage against the ratio derived from the coverage dataframe, ensuring the reported metric stays consistent with computed flow coverage values.
