### PR TITLE
fix: support mixed bool and float in maxp

### DIFF
--- a/spopt/region/maxp.py
+++ b/spopt/region/maxp.py
@@ -90,7 +90,7 @@ def maxp(
 
     """
     gdf, w = modify_components(gdf, w, threshold_name, threshold, policy=policy)
-    attr = np.atleast_2d(gdf[attrs_name].values)
+    attr = np.atleast_2d(gdf[attrs_name].to_numpy(dtype=float))
     if attr.shape[0] == 1:
         attr = attr.T
     threshold_array = gdf[threshold_name].values

--- a/spopt/tests/test_region/test_maxp.py
+++ b/spopt/tests/test_region/test_maxp.py
@@ -111,6 +111,22 @@ class TestMaxPHeuristic:
 
         numpy.testing.assert_array_equal(model.labels_, self.var1_labels)
 
+    def test_maxp_mixed_bool_float_attrs(self):
+        self.mexico["high_gdp"] = self.mexico["PCGDP2000"] > self.mexico[
+            "PCGDP2000"
+        ].median()
+        attrs_name = ["high_gdp", "PCGDP2000"]
+        threshold = 4
+        top_n = 2
+        threshold_name = "count"
+        numpy.random.seed(123456)
+        model = MaxPHeuristic(
+            self.mexico, self.w, attrs_name, threshold_name, threshold, top_n
+        )
+        model.solve()
+
+        assert len(model.labels_) == len(self.mexico)
+
     def test_infeasible_components(self):
         ifcs = infeasible_components(self.mexico, self.w, "count", 35)
         numpy.testing.assert_array_equal(ifcs, [0])


### PR DESCRIPTION
This PR fixes issue #498 by normalising MaxP covariate input to a numeric array before distance computation, which allows mixed `bool` and `float` columns to be used safely without triggering SciPy object-dtype errors, and it adds a regression test that builds a mixed bool+float attribute set and verifies `MaxPHeuristic.solve()` completes and returns labels for all observations.
