### PR TITLE
fix: repair FRLM VMT coverage fallback

### DIFF
--- a/spopt/locate/flow.py
+++ b/spopt/locate/flow.py
@@ -432,7 +432,8 @@ class FRLMCoverageMixin:
             self._calculate_path_distances()
 
         if not hasattr(self, "flow_coverage"):
-            self.calculate_flow_coverage()
+            self.flow_coverage = {}
+            self.get_flow_coverage()
 
         total_vmt = 0
         covered_vmt = 0

--- a/spopt/tests/test_locate/test_flow.py
+++ b/spopt/tests/test_locate/test_flow.py
@@ -426,6 +426,17 @@ class TestFRLMOutputsAndReporting:
         assert params["p_facilities"] == 2
         assert params["objective_type"] == "flow"
 
+    def test_vmt_coverage_without_flow_coverage_attr(self, setup_solved_model):
+        model = setup_solved_model
+        if hasattr(model, "flow_coverage"):
+            delattr(model, "flow_coverage")
+
+        metrics = model.get_vmt_coverage()
+
+        assert "total_vmt" in metrics
+        assert "covered_vmt" in metrics
+        assert "vmt_coverage_percentage" in metrics
+
 
 class TestFRLMCustomPaths:
     def test_custom_paths_basic(self):


### PR DESCRIPTION
This PR fixes issue #520 by correcting the fallback path in `FRLM.get_vmt_coverage()` so it initialises missing flow coverage state and delegates to the existing `get_flow_coverage()` method rather than calling a non-existent method, and it adds a regression test that removes `flow_coverage` before invocation to confirm the method now returns VMT metrics instead of raising `AttributeError`.
