### PR TITLE
fix: correct FRLM flow coverage annotation

### DIFF
--- a/spopt/locate/flow.py
+++ b/spopt/locate/flow.py
@@ -373,7 +373,7 @@ class FlowModelBuilder:
 class FRLMCoverageMixin:
     """Mixin to calculate flow coverage statistics for FRLM."""
 
-    def get_flow_coverage(self) -> None:
+    def get_flow_coverage(self) -> dict[str, float]:
         """Improved and fixed calculation of flow coverage."""
         if not hasattr(self, "facility_vars") or self.facility_vars is None:
             raise AttributeError(

--- a/spopt/tests/test_locate/test_flow.py
+++ b/spopt/tests/test_locate/test_flow.py
@@ -109,6 +109,7 @@ class TestFRLMObjectives:
         result = model.solve(solver=pulp.PULP_CBC_CMD(msg=0))
         assert result["status"] == "Optimal"
         coverage = model.get_flow_coverage()
+        assert isinstance(coverage, dict)
         assert coverage["covered_volume"] == 50
 
     def test_vmt_objective(self, setup_network_with_distances):


### PR DESCRIPTION
This PR fixes issue #524 by updating `FRLM.get_flow_coverage()` to use a dictionary return annotation that matches its actual return value, and it adds a small test assertion that checks the returned object type, which keeps the public API contract explicit for type checkers and editor tooling without changing runtime behaviour.
