### PR TITLE
only run CI for `push[main]`

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,8 +2,7 @@
 name: Continuous Integration
 on:
   push:
-    branches:
-      - "*"
+    branches: [main]
   pull_request:
     branches:
       - "*"


### PR DESCRIPTION
* only run CI for `push[main]`
* failure unrelated to this PR